### PR TITLE
i18n: localize the 'Copied!' timestamp toast

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -47,6 +47,9 @@
     "skipThreathold": {
         "message": "Maximum delay (seconds)"
     },
+    "copied": {
+        "message": "Copied!"
+    },
     "appDesc": {
         "message": "This extension syncs YouTube live streams in real-time by accelerating viewer-delayed streams caused by data reception delays."
     }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -47,6 +47,9 @@
     "skipThreathold": {
         "message": "遅延の上限秒数"
     },
+    "copied": {
+        "message": "コピーしました"
+    },
     "appDesc": {
         "message": "DVR が有効な YouTube のライブ配信で遅延が発生したときに、自動で再生速度を上げてリアルタイムに追いつく拡張機能"
     }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -47,6 +47,9 @@
     "skipThreathold": {
         "message": "Atraso máximo (segundos)"
     },
+    "copied": {
+        "message": "Copiado!"
+    },
     "appDesc": {
         "message": "Esta extensão sincroniza transmissões ao vivo do YouTube em tempo real acelerando transmissões atrasadas devido a atrasos na recepção de dados."
     }

--- a/content.js
+++ b/content.js
@@ -38,6 +38,7 @@ function main(common) {
             smoothAuto,
             skip,
             skipThreathold,
+            copied: chrome.i18n.getMessage('copied'),
         };
         const detail = navigator.userAgent.includes('Firefox') ? cloneInto(detailObject, document.defaultView) : detailObject;
         document.dispatchEvent(new CustomEvent('_live_catch_up_load_settings', { detail }));

--- a/inject.js
+++ b/inject.js
@@ -268,6 +268,9 @@
     document.addEventListener('_live_catch_up_load_settings', e => {
         const settings = e.detail;
         clearInterval(interval);
+        if (settings.copied) {
+            msg_current.innerHTML = HTMLPolicy.createHTML(`<span translate="no">${settings.copied}</span>`);
+        }
         showCurrent = settings.showCurrent;
         if (settings.enabled || settings.skip || settings.showPlaybackRate || settings.showLatency || settings.showHealth || settings.showEstimation || settings.showCurrent) {
             interval = setInterval(() => {


### PR DESCRIPTION
The click-to-copy timestamp toast was the only UI string hardcoded in English. Since inject.js runs in the page's MAIN world and can't call chrome.i18n, the localized string is passed through the existing _live_catch_up_load_settings CustomEvent (read in content.js). Adds a 'copied' key to the en, ja and pt_BR locales.
